### PR TITLE
feat: show map centered on user location

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,8 @@ const artTitle = document.getElementById('art-title');
 const artImage = document.getElementById('art-image');
 const artDescription = document.getElementById('art-description');
 
+let map;
+
 function distanceMeters(lat1, lon1, lat2, lon2) {
   const R = 6371e3;
   const toRad = deg => deg * Math.PI / 180;
@@ -33,6 +35,14 @@ function showError(err) {
 if ('geolocation' in navigator) {
   navigator.geolocation.getCurrentPosition(position => {
     const { latitude, longitude } = position.coords;
+    map = L.map('map').setView([latitude, longitude], 15);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    L.marker([latitude, longitude]).addTo(map).bindPopup('現在地').openPopup();
+    artworks.forEach(a => {
+      L.marker([a.lat, a.lng]).addTo(map).bindPopup(a.title);
+    });
     const nearby = artworks.find(a => distanceMeters(latitude, longitude, a.lat, a.lng) < THRESHOLD_METERS);
     if (nearby) {
       status.textContent = "ようこそ！";

--- a/public/index.html
+++ b/public/index.html
@@ -4,15 +4,21 @@
   <meta charset="UTF-8">
   <title>街角美術館</title>
   <link rel="stylesheet" href="style.css">
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet/dist/leaflet.css"
+  />
 </head>
 <body>
   <h1>街角美術館</h1>
   <p id="status">現在位置を確認しています...</p>
+  <div id="map"></div>
   <div id="artwork" class="hidden">
     <h2 id="art-title"></h2>
     <img id="art-image" src="" alt="">
     <p id="art-description"></p>
   </div>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -9,3 +9,8 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+#map {
+  height: 400px;
+  margin: 1rem 0;
+}


### PR DESCRIPTION
## Summary
- add Leaflet map and dependencies
- center map on user location and show artwork markers

## Testing
- `npm test`
- `node server.js` (start and stop)

------
https://chatgpt.com/codex/tasks/task_e_6891722a56b48327b802242142dd70c4