### PR TITLE
feat: add tab navigation for map and posting

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,10 @@ const artTitle = document.getElementById('art-title');
 const artImage = document.getElementById('art-image');
 const artAudio = document.getElementById('art-audio');
 const artDescription = document.getElementById('art-description');
+const mapSection = document.getElementById('map-section');
+const postSection = document.getElementById('post-section');
+const tabMap = document.getElementById('tab-map');
+const tabPost = document.getElementById('tab-post');
 
 let map;
 let userLat;
@@ -35,6 +39,23 @@ function distanceMeters(lat1, lon1, lat2, lon2) {
 function showError(err) {
   status.textContent = `位置情報を取得できません: ${err.message}`;
 }
+
+tabMap.addEventListener('click', () => {
+  mapSection.classList.remove('hidden');
+  postSection.classList.add('hidden');
+  tabMap.classList.add('active');
+  tabPost.classList.remove('active');
+  if (map) {
+    setTimeout(() => map.invalidateSize(), 0);
+  }
+});
+
+tabPost.addEventListener('click', () => {
+  mapSection.classList.add('hidden');
+  postSection.classList.remove('hidden');
+  tabPost.classList.add('active');
+  tabMap.classList.remove('active');
+});
 
 if ('geolocation' in navigator) {
   navigator.geolocation.getCurrentPosition(position => {

--- a/public/index.html
+++ b/public/index.html
@@ -12,20 +12,30 @@
 </head>
 <body>
   <h1>街角美術館</h1>
-  <p id="status">現在位置を確認しています...</p>
-  <div id="map"></div>
-  <div id="artwork" class="hidden">
-    <h2 id="art-title"></h2>
-    <img id="art-image" src="" alt="">
-    <audio id="art-audio" controls class="hidden"></audio>
-    <p id="art-description"></p>
+  <div class="tabs">
+    <button id="tab-map" class="active">地図</button>
+    <button id="tab-post">投稿</button>
   </div>
-  <h2>作品を投稿</h2>
-  <form id="post-form">
-    <input type="text" id="new-title" placeholder="タイトル">
-    <input type="file" id="new-file" accept="image/*,audio/*">
-    <button type="button" id="post-btn">投稿</button>
-  </form>
+
+  <div id="map-section">
+    <p id="status">現在位置を確認しています...</p>
+    <div id="map"></div>
+    <div id="artwork" class="hidden">
+      <h2 id="art-title"></h2>
+      <img id="art-image" src="" alt="">
+      <audio id="art-audio" controls class="hidden"></audio>
+      <p id="art-description"></p>
+    </div>
+  </div>
+
+  <div id="post-section" class="hidden">
+    <h2>作品を投稿</h2>
+    <form id="post-form">
+      <input type="text" id="new-title" placeholder="タイトル">
+      <input type="file" id="new-file" accept="image/*,audio/*">
+      <button type="button" id="post-btn">投稿</button>
+    </form>
+  </div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="app.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -7,6 +7,21 @@ body {
   display: none;
 }
 
+.tabs {
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  padding: 0.5rem 1rem;
+  margin-right: 0.5rem;
+  cursor: pointer;
+}
+
+.tabs button.active {
+  background: #333;
+  color: #fff;
+}
+
 img {
   max-width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- separate map and post form into tabs
- style tab buttons
- handle tab switching in JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68917ef666c88327a8ad5b925222ce9f