### PR TITLE
Differentiate user location marker

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -66,7 +66,12 @@ if ('geolocation' in navigator) {
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
-    L.marker([latitude, longitude]).addTo(map).bindPopup('現在地').openPopup();
+    L.circleMarker([latitude, longitude], {
+      radius: 8,
+      color: 'red',
+      fillColor: 'red',
+      fillOpacity: 0.5
+    }).addTo(map).bindPopup('現在地').openPopup();
     const storedArtworks = JSON.parse(localStorage.getItem('userArtworks') || '[]');
     artworks = DEFAULT_ARTWORKS.concat(storedArtworks);
     artworks.forEach(a => {


### PR DESCRIPTION
## Summary
- show the user's location with a red circle marker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68917fd93f008327be899f0bec451685