### PR TITLE
style: highlight media markers with transparent speech bubbles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
         <input type="text" id="location-input" placeholder="場所を検索">
         <button type="button" id="search-btn">検索</button>
         <p id="search-status"></p>
+        <ul id="search-results"></ul>
       </div>
       <button type="button" id="post-btn">投稿</button>
     </form>

--- a/public/style.css
+++ b/public/style.css
@@ -35,8 +35,17 @@ img {
 
 .media-marker {
   font-size: 24px;
-  line-height: 24px;
+  width: 32px;
+  height: 32px;
   text-align: center;
+  border-radius: 50%;
+  background: transparent;
+  border: 2px solid rgba(128, 128, 128, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  outline: none;
 }
 
 @media (max-width: 600px) {
@@ -47,4 +56,19 @@ img {
   #map {
     height: 50vh;
   }
+}
+
+#search-results {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0;
+}
+
+#search-results li {
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+#search-results li.selected {
+  background: #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- surround media marker icons with a transparent gray circle so they resemble a speech bubble without obscuring the map
- merge latest main to incorporate location search results and click-to-view posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891830031148327aa276e2a29fda9c1