### PR TITLE
style: add transparent gray ring to media icons

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -42,6 +42,8 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
+  border: 2px solid rgba(128, 128, 128, 0.5);
+  background-color: transparent;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- show media icon inside circular marker with semi-transparent gray rim

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918852cc988327b5a358ee0afb55f2