### PR TITLE
Standardize interface language to English

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,15 +1,15 @@
 const DEFAULT_ARTWORKS = [
   {
-    title: "広島大学中央図書館",
+    title: "Hiroshima University Central Library",
     lat: 34.403244,
     lng: 132.713469,
     image: "higashihiroshima.jpeg",
-    description: "広島大学東広島キャンパスの中央図書館です。",
+    description: "Central library at Hiroshima University's Higashihiroshima Campus.",
     type: 'image'
   }
 ];
 
-const THRESHOLD_METERS = 50; // 50m以内で表示
+const THRESHOLD_METERS = 50; // display within 50m
 
 const status = document.getElementById('status');
 const artworkDiv = document.getElementById('artwork');
@@ -51,10 +51,6 @@ let selectedLat;
 let selectedLng;
 let searchMarker;
 
-function getMediaLabel(type) {
-  return type === 'audio' ? 'Audio' : 'Image';
-}
-
 function distanceMeters(lat1, lon1, lat2, lon2) {
   const R = 6371e3;
   const toRad = deg => deg * Math.PI / 180;
@@ -66,7 +62,7 @@ function distanceMeters(lat1, lon1, lat2, lon2) {
 }
 
 function showError(err) {
-  status.textContent = `位置情報を取得できません: ${err.message}`;
+  status.textContent = `Unable to retrieve location: ${err.message}`;
 }
 
 tabMap.addEventListener('click', () => {
@@ -99,7 +95,7 @@ for (const input of locModeInputs) {
 searchBtn.addEventListener('click', () => {
   const query = locationInput.value.trim();
   if (!query) return;
-  searchStatus.textContent = '検索中...';
+  searchStatus.textContent = 'Searching...';
   searchResults.innerHTML = '';
   fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}`)
     .then(res => res.json())
@@ -107,14 +103,14 @@ searchBtn.addEventListener('click', () => {
       if (data.length > 0) {
         selectedLat = null;
         selectedLng = null;
-        searchStatus.textContent = '検索結果を選択';
+        searchStatus.textContent = 'Select a result';
         data.slice(0, 5).forEach(result => {
           const li = document.createElement('li');
           li.textContent = result.display_name;
           li.addEventListener('click', () => {
             selectedLat = parseFloat(result.lat);
             selectedLng = parseFloat(result.lon);
-            searchStatus.textContent = `選択中: ${result.display_name}`;
+            searchStatus.textContent = `Selected: ${result.display_name}`;
             if (searchMarker) {
               map.removeLayer(searchMarker);
             }
@@ -128,11 +124,11 @@ searchBtn.addEventListener('click', () => {
           searchResults.appendChild(li);
         });
       } else {
-        searchStatus.textContent = '場所が見つかりません';
+        searchStatus.textContent = 'No locations found';
       }
     })
     .catch(() => {
-      searchStatus.textContent = '検索エラー';
+      searchStatus.textContent = 'Search error';
     });
 });
 
@@ -150,26 +146,26 @@ if ('geolocation' in navigator) {
       color: 'red',
       fillColor: 'red',
       fillOpacity: 0.5
-    }).addTo(map).bindPopup('現在地').openPopup();
+    }).addTo(map).bindPopup('Current location').openPopup();
     const storedArtworks = JSON.parse(localStorage.getItem('userArtworks') || '[]');
     artworks = DEFAULT_ARTWORKS.concat(storedArtworks);
     artworks.forEach(a => {
       const icon = a.type === 'audio' ? audioIcon : imageIcon;
-      const popupContent = `${getMediaLabel(a.type)}: ${a.title}`;
+      const popupContent = a.title;
       const marker = L.marker([a.lat, a.lng], { icon }).addTo(map).bindPopup(popupContent);
       marker.on('click', () => showArtwork(a));
     });
-    status.textContent = "近くのマーカーをクリックすると作品を閲覧できます。";
+    status.textContent = "Click nearby markers to view artworks.";
   }, showError);
 } else {
-  status.textContent = "このブラウザは位置情報に対応していません。";
+  status.textContent = "This browser does not support geolocation.";
 }
 
 function showArtwork(art) {
   const within = distanceMeters(userLat, userLng, art.lat, art.lng) < THRESHOLD_METERS;
   if (within) {
-    status.textContent = "ようこそ！";
-    artTitle.textContent = `${getMediaLabel(art.type)}: ${art.title}`;
+    status.textContent = "Welcome!";
+    artTitle.textContent = art.title;
     if (art.type === 'audio') {
       artImage.classList.add('hidden');
       artAudio.classList.remove('hidden');
@@ -182,7 +178,7 @@ function showArtwork(art) {
     artDescription.textContent = art.description || '';
     artworkDiv.classList.remove('hidden');
   } else {
-    status.textContent = "指定の地点に移動してから作品をご覧ください。";
+    status.textContent = "Move to the specified location to view the artwork.";
     artworkDiv.classList.add('hidden');
   }
 }
@@ -215,10 +211,10 @@ document.getElementById('post-btn').addEventListener('click', () => {
     localStorage.setItem('userArtworks', JSON.stringify(stored));
     artworks.push(newArt);
     const icon = newArt.type === 'audio' ? audioIcon : imageIcon;
-    const popupContent = `${getMediaLabel(newArt.type)}: ${newArt.title}`;
+    const popupContent = newArt.title;
     const marker = L.marker([newArt.lat, newArt.lng], { icon }).addTo(map).bindPopup(popupContent);
     marker.on('click', () => showArtwork(newArt));
-    alert('投稿しました');
+    alert('Posted successfully');
   };
   reader.readAsDataURL(file);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>街角美術館</title>
+  <title>Street Museum</title>
   <link rel="stylesheet" href="style.css">
   <link
     rel="stylesheet"
@@ -11,14 +11,14 @@
   />
 </head>
 <body>
-  <h1>街角美術館</h1>
+  <h1>Street Museum</h1>
   <div class="tabs">
-    <button id="tab-map" class="active">地図</button>
-    <button id="tab-post">投稿</button>
+    <button id="tab-map" class="active">Map</button>
+    <button id="tab-post">Post</button>
   </div>
 
   <div id="map-section">
-    <p id="status">現在位置を確認しています...</p>
+    <p id="status">Checking current location...</p>
     <div id="map"></div>
     <div id="artwork" class="hidden">
       <h2 id="art-title"></h2>
@@ -29,21 +29,21 @@
   </div>
 
   <div id="post-section" class="hidden">
-    <h2>作品を投稿</h2>
+    <h2>Post Artwork</h2>
     <form id="post-form">
-      <input type="text" id="new-title" placeholder="タイトル">
+      <input type="text" id="new-title" placeholder="Title">
       <input type="file" id="new-file" accept="image/*,audio/*">
       <div class="location-options">
-        <label><input type="radio" name="loc-mode" value="current" checked> 現在地を使用</label>
-        <label><input type="radio" name="loc-mode" value="search"> 場所名で検索</label>
+        <label><input type="radio" name="loc-mode" value="current" checked> Use current location</label>
+        <label><input type="radio" name="loc-mode" value="search"> Search by place name</label>
       </div>
       <div id="search-box" class="hidden">
-        <input type="text" id="location-input" placeholder="場所を検索">
-        <button type="button" id="search-btn">検索</button>
+        <input type="text" id="location-input" placeholder="Search location">
+        <button type="button" id="search-btn">Search</button>
         <p id="search-status"></p>
         <ul id="search-results"></ul>
       </div>
-      <button type="button" id="post-btn">投稿</button>
+      <button type="button" id="post-btn">Post</button>
     </form>
   </div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- Translate client HTML and JavaScript from Japanese to English
- Remove auto-generated media labels so user titles display verbatim

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918c60446483278802506fc5fbc643