### PR TITLE
Adjust layout for landscape orientation

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -70,3 +70,23 @@ img {
 #search-results li.selected {
   background: #e0e0e0;
 }
+
+@media (orientation: landscape) {
+  #map-section {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  #status {
+    width: 100%;
+  }
+  #map,
+  #artwork {
+    flex: 1;
+  }
+  #artwork {
+    margin-left: 1rem;
+  }
+  #map {
+    height: 80vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Display map and artwork side-by-side on landscape screens
- Leave vertical layout untouched for portrait screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689191e114b883279056390cbceac6ac