### PR TITLE
Fix Leaflet map display after initial load

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -181,6 +181,8 @@ function initMap(lat, lng, showUserMarker = false) {
     }).addTo(map).bindPopup(t('currentLocation')).openPopup();
   }
   setStatus('clickNearby');
+  // Ensure map tiles render correctly on initial load
+  setTimeout(() => map.invalidateSize(), 0);
 }
 
 function distanceMeters(lat1, lon1, lat2, lon2) {


### PR DESCRIPTION
## Summary
- ensure Leaflet map resizes on initial load by invalidating size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891a824fcac8327adc98fdbf548bde8