### PR TITLE
Fix Leaflet map display after initial load

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -159,6 +159,12 @@ let selectedLng;
 let searchMarker;
 let userMarker;
 
+window.addEventListener('resize', () => {
+  if (map) {
+    setTimeout(() => map.invalidateSize(), 0);
+  }
+});
+
 function initMap(lat, lng, showUserMarker = false) {
   map = L.map('map').setView([lat, lng], 15);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -181,6 +187,8 @@ function initMap(lat, lng, showUserMarker = false) {
     }).addTo(map).bindPopup(t('currentLocation')).openPopup();
   }
   setStatus('clickNearby');
+  // Ensure map tiles render correctly on initial load
+  setTimeout(() => map.invalidateSize(), 0);
 }
 
 function distanceMeters(lat1, lon1, lat2, lon2) {


### PR DESCRIPTION
## Summary
- ensure Leaflet map resizes on initial load by invalidating size
- invalidate map size on window resize to keep tiles visible after viewport changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a824fcac8327adc98fdbf548bde8