### PR TITLE
Fix map disappearing after orientation layout change

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -159,6 +159,12 @@ let selectedLng;
 let searchMarker;
 let userMarker;
 
+window.addEventListener('resize', () => {
+  if (map) {
+    setTimeout(() => map.invalidateSize(), 0);
+  }
+});
+
 function initMap(lat, lng, showUserMarker = false) {
   map = L.map('map').setView([lat, lng], 15);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -181,6 +187,8 @@ function initMap(lat, lng, showUserMarker = false) {
     }).addTo(map).bindPopup(t('currentLocation')).openPopup();
   }
   setStatus('clickNearby');
+  // Ensure map tiles render correctly on initial load
+  setTimeout(() => map.invalidateSize(), 0);
 }
 
 function distanceMeters(lat1, lon1, lat2, lon2) {

--- a/public/style.css
+++ b/public/style.css
@@ -71,22 +71,3 @@ img {
   background: #e0e0e0;
 }
 
-@media (orientation: landscape) {
-  #map-section {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  #status {
-    width: 100%;
-  }
-  #map,
-  #artwork {
-    flex: 1;
-  }
-  #artwork {
-    margin-left: 1rem;
-  }
-  #map {
-    height: 80vh;
-  }
-}


### PR DESCRIPTION
## Summary
- ensure Leaflet map resizes on initial load by invalidating size
- invalidate map size on window resize to keep tiles visible after viewport changes
- remove landscape-specific flex layout that hid the map on wide viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a824fcac8327adc98fdbf548bde8