### PR TITLE
Simplify map background

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -167,8 +167,10 @@ window.addEventListener('resize', () => {
 
 function initMap(lat, lng, showUserMarker = false) {
   map = L.map('map').setView([lat, lng], 15);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; OpenStreetMap contributors'
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
+    subdomains: 'abcd',
+    maxZoom: 19
   }).addTo(map);
   const storedArtworks = JSON.parse(localStorage.getItem('userArtworks') || '[]');
   artworks = DEFAULT_ARTWORKS.concat(storedArtworks);

--- a/public/style.css
+++ b/public/style.css
@@ -33,6 +33,10 @@ img {
   margin: 1rem 0;
 }
 
+#map .leaflet-tile-pane {
+  filter: sepia(80%);
+}
+
 .media-marker {
   font-size: 24px;
   width: 32px;


### PR DESCRIPTION
## Summary
- Switch to a low-detail, no-label CARTO tile layer
- Apply sepia filter to tile pane to create canvas-like background for artwork

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892da52a5bc83278bb31f802431d6a3