### PR TITLE
Simplify map style for better artwork focus

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -167,8 +167,10 @@ window.addEventListener('resize', () => {
 
 function initMap(lat, lng, showUserMarker = false) {
   map = L.map('map').setView([lat, lng], 15);
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: '&copy; OpenStreetMap contributors'
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png', {
+    attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
+    maxZoom: 19,
+    opacity: 0.5
   }).addTo(map);
   const storedArtworks = JSON.parse(localStorage.getItem('userArtworks') || '[]');
   artworks = DEFAULT_ARTWORKS.concat(storedArtworks);

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,11 @@
   />
 </head>
 <body>
+  <svg style="position:absolute;width:0;height:0">
+    <filter id="sepia">
+      <feColorMatrix type="matrix" values="0.393 0.769 0.189 0 0 0.349 0.686 0.168 0 0 0.272 0.534 0.131 0 0 0 0 0 1 0"/>
+    </filter>
+  </svg>
   <h1 id="title">街角ミュージアム</h1>
   <select id="language-select">
     <option value="ja" selected>日本語</option>

--- a/public/style.css
+++ b/public/style.css
@@ -33,6 +33,10 @@ img {
   margin: 1rem 0;
 }
 
+.leaflet-tile {
+  filter: url(#sepia);
+}
+
 .media-marker {
   font-size: 24px;
   width: 32px;


### PR DESCRIPTION
## Summary
- Use a minimalist CARTO light tile layer with reduced opacity to de-emphasize map details
- Add an SVG color matrix and CSS filter to render map tiles in a sepia tone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892f06beca08327a9038e2432b6fe40