### PR TITLE
Use thumbnails with proximity glow

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -50,6 +50,43 @@ img {
   background-color: rgba(230, 230, 230, 0.7);
 }
 
+.thumb-marker {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 10px rgba(255, 255, 0, var(--glow, 0));
+  animation: pulse 2s infinite;
+}
+
+.thumb-marker img,
+.thumb-marker .thumb-audio {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.thumb-marker .thumb-audio {
+  font-size: 24px;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 5px rgba(255, 255, 0, var(--glow, 0));
+  }
+  50% {
+    box-shadow: 0 0 15px rgba(255, 255, 0, var(--glow, 0));
+  }
+  100% {
+    box-shadow: 0 0 5px rgba(255, 255, 0, var(--glow, 0));
+  }
+}
+
 @media (max-width: 600px) {
   body {
     margin: 1rem;


### PR DESCRIPTION
## Summary
- Display image media as circular map markers showing the thumbnail
- Animate a pulsing pale glow around markers whose strength increases as users approach
- Track user location continuously to update glow intensity and apply effect to newly posted media

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f2b1ee308327a5a91680f85e165f