### PR TITLE
Add Art Presence exploration mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,8 @@
 
   <div id="map-section">
     <p id="status">現在地を確認しています...</p>
+    <button id="presence-toggle"></button>
+    <div id="arrow" class="hidden"></div>
     <div id="map"></div>
     <div id="artwork" class="hidden">
       <h2 id="art-title"></h2>

--- a/public/style.css
+++ b/public/style.css
@@ -112,3 +112,13 @@ img {
   background: #e0e0e0;
 }
 
+#arrow {
+  width: 0;
+  height: 0;
+  border-left: 20px solid transparent;
+  border-right: 20px solid transparent;
+  border-bottom: 40px solid red;
+  margin: 1rem auto;
+  transition: transform 0.2s linear;
+}
+


### PR DESCRIPTION
## Summary
- Hide the map and guide users with a directional arrow in the new Art Presence exploration mode
- Gradually reveal artwork images or audio as the user approaches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689303f67bcc83279bfde20a8a7e5e0c