### PR TITLE
feat: unlock artwork with full-screen overlay

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -22,7 +22,9 @@ const translations = {
     welcome: "ようこそ！",
     moveToView: "指定された場所に移動して作品を表示してください。",
     explore: "探索モード",
-    postedSuccessfully: "投稿に成功しました"
+    postedSuccessfully: "投稿に成功しました",
+    welcomeTo: "\u3088\u3046\u3053\u305d",
+    insideArt: "\u3042\u306a\u305f\u306f\u4eca\u3001\u30a2\u30fc\u30c8\u306e\u4e2d\u306b\u3044\u307e\u3059"
   },
   en: {
     title: "Street Museum",
@@ -47,7 +49,9 @@ const translations = {
     welcome: "Welcome!",
     moveToView: "Move to the specified location to view the artwork.",
     explore: "Explore Mode",
-    postedSuccessfully: "Posted successfully"
+    postedSuccessfully: "Posted successfully",
+    welcomeTo: "Welcome to",
+    insideArt: "You are now inside the art"
   }
 };
 
@@ -95,6 +99,10 @@ function updateTexts() {
       a.marker.bindPopup(getTitle(a));
     }
   });
+  if (activeOverlayArt) {
+    unlockWelcome.textContent = `${t('welcomeTo')} ${getTitle(activeOverlayArt)}`;
+    unlockInside.textContent = t('insideArt');
+  }
 }
 
 document.getElementById('language-select').addEventListener('change', e => {
@@ -139,6 +147,10 @@ const searchStatus = document.getElementById('search-status');
 const searchResults = document.getElementById('search-results');
 const presenceToggle = document.getElementById('presence-toggle');
 const arrow = document.getElementById('arrow');
+const unlockOverlay = document.getElementById('unlock-overlay');
+const unlockImage = document.getElementById('unlock-image');
+const unlockWelcome = document.getElementById('unlock-welcome');
+const unlockInside = document.getElementById('unlock-inside');
 
 function createImageIcon(url) {
   return L.divIcon({
@@ -167,6 +179,7 @@ let searchMarker;
 let userMarker;
 let artPresenceMode = false;
 let currentPresenceTarget;
+let activeOverlayArt;
 
 window.addEventListener('resize', () => {
   if (map) {
@@ -262,6 +275,44 @@ function updatePresence() {
     artImage.style.filter = `blur(${blur}px)`;
   }
   artDescription.textContent = minDist < THRESHOLD_METERS ? getDescription(nearest) : '';
+}
+
+function showFullScreenArt(art) {
+  unlockWelcome.textContent = `${t('welcomeTo')} ${getTitle(art)}`;
+  unlockInside.textContent = t('insideArt');
+  if (art.type === 'audio') {
+    unlockImage.classList.add('hidden');
+  } else {
+    unlockImage.classList.remove('hidden');
+    unlockImage.src = art.image || art.data;
+  }
+  unlockOverlay.classList.remove('hidden');
+  requestAnimationFrame(() => unlockOverlay.classList.add('show'));
+}
+
+function hideFullScreenArt() {
+  unlockOverlay.classList.remove('show');
+  setTimeout(() => {
+    unlockOverlay.classList.add('hidden');
+  }, 1000);
+}
+
+function checkUnlocked() {
+  if (userLat == null || userLng == null) return;
+  let found = null;
+  artworks.forEach(a => {
+    const d = distanceMeters(userLat, userLng, a.lat, a.lng);
+    if (d < THRESHOLD_METERS) {
+      found = a;
+    }
+  });
+  if (found && activeOverlayArt !== found) {
+    activeOverlayArt = found;
+    showFullScreenArt(found);
+  } else if (!found && activeOverlayArt) {
+    hideFullScreenArt();
+    activeOverlayArt = null;
+  }
 }
 
 function showError(err) {
@@ -370,6 +421,7 @@ if ('geolocation' in navigator) {
       updateGlow();
       updatePresence();
     }
+    checkUnlocked();
   }, showError, { enableHighAccuracy: true });
 } else {
   const def = DEFAULT_ARTWORKS[0];
@@ -377,6 +429,7 @@ if ('geolocation' in navigator) {
   userLng = def.lng;
   setStatus('noLocationSupport');
   initMap(def.lat, def.lng);
+  checkUnlocked();
 }
 
 function showArtwork(art) {

--- a/public/index.html
+++ b/public/index.html
@@ -57,6 +57,13 @@
       <button type="button" id="post-btn">投稿</button>
     </form>
   </div>
+  <div id="unlock-overlay" class="hidden">
+    <img id="unlock-image" src="" alt="">
+    <div id="unlock-text">
+      <h2 id="unlock-welcome"></h2>
+      <p id="unlock-inside"></p>
+    </div>
+  </div>
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="app.js"></script>
 </body>

--- a/public/style.css
+++ b/public/style.css
@@ -122,3 +122,38 @@ img {
   transition: transform 0.2s linear;
 }
 
+#unlock-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+#unlock-overlay.show {
+  opacity: 1;
+}
+
+#unlock-overlay img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
+}
+
+#unlock-text {
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- Fade-in full-screen overlay unlocks when user approaches an artwork via GPS, showing welcome messaging
- Overlay hides UI and displays artwork imagery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689306381bbc8327b29fe377b7f2650f