### PR TITLE
Add gallery view and journey tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
   <div class="tabs">
     <button id="tab-map" class="active">マップ</button>
     <button id="tab-post">投稿</button>
+    <button id="tab-gallery">ギャラリー</button>
   </div>
 
   <div id="map-section">
@@ -66,6 +67,10 @@
       </div>
       <button type="button" id="post-btn">投稿</button>
     </form>
+  </div>
+  <div id="gallery-section" class="hidden">
+    <h2 id="gallery-heading"></h2>
+    <div id="gallery-list"></div>
   </div>
   <div id="unlock-overlay" class="hidden">
     <img id="unlock-image" src="" alt="">

--- a/public/style.css
+++ b/public/style.css
@@ -162,3 +162,44 @@ img {
   margin: 0.5rem 0;
 }
 
+#gallery-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+#gallery-section h2 {
+  width: 100%;
+  margin-top: 0;
+}
+
+#gallery-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.art-card {
+  width: 150px;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+.art-card img,
+.art-card .thumb-audio {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+}
+
+.art-card h3 {
+  font-size: 1rem;
+  margin: 0.5rem 0 0.25rem 0;
+}
+
+.art-card p {
+  margin: 0;
+  font-size: 0.8rem;
+}
+


### PR DESCRIPTION
## Summary
- Add a Gallery tab displaying visited artworks with viewing time and notes
- Track visited artwork locations and draw a journey polyline on the map
- Localize new gallery interface elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68930ba21ab08327b107b658b47ed1d4