### PR TITLE
Indicate proximity in art presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -22,6 +22,7 @@ const translations = {
     welcome: "ようこそ！",
     moveToView: "指定された場所に移動して作品を表示してください。",
     presence: "アート気配モード",
+    inRange: "50m以内です！",
     postedSuccessfully: "投稿に成功しました"
   },
   en: {
@@ -47,6 +48,7 @@ const translations = {
     welcome: "Welcome!",
     moveToView: "Move to the specified location to view the artwork.",
     presence: "Art Presence",
+    inRange: "Within 50m!",
     postedSuccessfully: "Posted successfully"
   }
 };
@@ -249,6 +251,9 @@ function updatePresence() {
     }
   });
   if (!nearest) return;
+  const within = minDist < THRESHOLD_METERS;
+  arrow.classList.toggle('in-range', within);
+  setStatus(within ? 'inRange' : 'moveToView');
   currentPresenceTarget = nearest;
   const angle = bearingTo(userLat, userLng, nearest.lat, nearest.lng);
   arrow.style.transform = `rotate(${angle}deg)`;
@@ -268,10 +273,10 @@ function updatePresence() {
     artAudio.classList.add('hidden');
     artImage.classList.remove('hidden');
     artImage.src = nearest.image || nearest.data;
-    const blur = 20 * ratio;
-    artImage.style.filter = `blur(${blur}px)`;
+    const blur = within ? 0 : 20 * ratio;
+    artImage.style.filter = blur ? `blur(${blur}px)` : 'none';
   }
-  artDescription.textContent = minDist < THRESHOLD_METERS ? getDescription(nearest) : '';
+  artDescription.textContent = within ? getDescription(nearest) : '';
 }
 
 function showError(err) {

--- a/public/style.css
+++ b/public/style.css
@@ -122,3 +122,7 @@ img {
   transition: transform 0.2s linear;
 }
 
+#arrow.in-range {
+  border-bottom-color: green;
+}
+


### PR DESCRIPTION
## Summary
- Add translations for new in-range message
- Highlight arrow green and show message when within 50m of artwork
- Show artwork without blur when within 50m

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934c4f1d788327b6d4db14353686a7