### PR TITLE
Add full-screen artwork overlay

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -66,6 +66,14 @@ function getDescription(a) {
   return typeof a.description === 'string' ? a.description : (a.description[currentLang] || a.description.ja || a.description.en || '');
 }
 
+function getWelcomeMessage(title) {
+  return currentLang === 'ja' ? `${title}へようこそ` : `Welcome to ${title}`;
+}
+
+function getEnjoyMessage(title) {
+  return currentLang === 'ja' ? `${title}を五感でお楽しみください` : `Enjoy ${title} with all of your senses`;
+}
+
 let currentStatusKey = 'checkingLocation';
 let currentStatusExtra = '';
 function setStatus(key, extra = '') {
@@ -126,6 +134,8 @@ const THRESHOLD_METERS = 50; // display within 50m
 const status = document.getElementById('status');
 const artworkDiv = document.getElementById('artwork');
 const artTitle = document.getElementById('art-title');
+const artMessage = document.getElementById('art-message');
+const artClose = document.getElementById('art-close');
 const artImage = document.getElementById('art-image');
 const artAudio = document.getElementById('art-audio');
 const artDescription = document.getElementById('art-description');
@@ -258,7 +268,9 @@ function updatePresence() {
   const angle = bearingTo(userLat, userLng, nearest.lat, nearest.lng);
   arrow.style.transform = `rotate(${angle}deg)`;
   artworkDiv.classList.remove('hidden');
+  artworkDiv.classList.add('show');
   artTitle.textContent = getTitle(nearest);
+  artMessage.textContent = '';
   const ratio = Math.min(minDist / 200, 1);
   if (nearest.type === 'audio') {
     artImage.classList.add('hidden');
@@ -319,6 +331,7 @@ presenceToggle.addEventListener('click', () => {
   document.getElementById('map').classList.toggle('hidden', artPresenceMode);
   arrow.classList.toggle('hidden', !artPresenceMode);
   if (!artPresenceMode) {
+    artworkDiv.classList.remove('show');
     artworkDiv.classList.add('hidden');
     artImage.style.filter = '';
     if (currentPresenceTarget && currentPresenceTarget.type === 'audio') {
@@ -327,6 +340,16 @@ presenceToggle.addEventListener('click', () => {
   }
   updateTexts();
   updatePresence();
+});
+
+artClose.addEventListener('click', () => {
+  artworkDiv.classList.remove('show');
+  setTimeout(() => {
+    artworkDiv.classList.add('hidden');
+    if (!artAudio.classList.contains('hidden')) {
+      artAudio.pause();
+    }
+  }, 500);
 });
 
 searchBtn.addEventListener('click', () => {
@@ -398,7 +421,9 @@ function showArtwork(art) {
   const within = distanceMeters(userLat, userLng, art.lat, art.lng) < THRESHOLD_METERS;
   if (within) {
     setStatus('welcome');
-    artTitle.textContent = getTitle(art);
+    const title = getTitle(art);
+    artTitle.textContent = getWelcomeMessage(title);
+    artMessage.textContent = getEnjoyMessage(title);
     if (art.type === 'audio') {
       artImage.classList.add('hidden');
       artAudio.classList.remove('hidden');
@@ -410,8 +435,10 @@ function showArtwork(art) {
     }
     artDescription.textContent = getDescription(art);
     artworkDiv.classList.remove('hidden');
+    requestAnimationFrame(() => artworkDiv.classList.add('show'));
   } else {
     setStatus('moveToView');
+    artworkDiv.classList.remove('show');
     artworkDiv.classList.add('hidden');
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,9 @@
     <div id="arrow" class="hidden"></div>
     <div id="map"></div>
     <div id="artwork" class="hidden">
+      <span id="art-close" class="close">&times;</span>
       <h2 id="art-title"></h2>
+      <p id="art-message"></p>
       <img id="art-image" src="" alt="">
       <audio id="art-audio" controls class="hidden"></audio>
       <p id="art-description"></p>

--- a/public/style.css
+++ b/public/style.css
@@ -126,3 +126,40 @@ img {
   border-bottom-color: green;
 }
 
+#artwork {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+#artwork.show {
+  opacity: 1;
+}
+
+#artwork .close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+#art-image {
+  max-width: 90%;
+  max-height: 70vh;
+  object-fit: contain;
+  margin-top: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- Show artwork in a full-screen popup with fade-in and close button
- Display Japanese welcome/enjoy messages with unlocked artwork

## Testing
- `npm test`
- `node --check public/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68934efddff08327be7a38db2f0e9727