### PR TITLE
Add text labels for sensory feedback inputs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -72,7 +72,7 @@ function getArtworkId(a) {
 
 function loadSenses(a) {
   const all = JSON.parse(localStorage.getItem('artworkSenses') || '{}');
-  return all[getArtworkId(a)] || { sound: '', light: '', wind: '', smell: '', temperature: '' };
+  return all[getArtworkId(a)] || { sound: '', temperature: '', smell: '', weather: '' };
 }
 
 function storeSenses(a, senses) {
@@ -85,10 +85,9 @@ function populateSenses(a) {
   currentArtwork = a;
   const senses = loadSenses(a);
   senseInputs.sound.value = senses.sound || '';
-  senseInputs.light.value = senses.light || '';
-  senseInputs.wind.value = senses.wind || '';
-  senseInputs.smell.value = senses.smell || '';
   senseInputs.temperature.value = senses.temperature || '';
+  senseInputs.smell.value = senses.smell || '';
+  senseInputs.weather.value = senses.weather || '';
   sensesDiv.classList.remove('hidden');
 }
 
@@ -176,10 +175,9 @@ const arrow = document.getElementById('arrow');
 const sensesDiv = document.getElementById('senses');
 const senseInputs = {
   sound: document.getElementById('sense-sound'),
-  light: document.getElementById('sense-light'),
-  wind: document.getElementById('sense-wind'),
+  temperature: document.getElementById('sense-temp'),
   smell: document.getElementById('sense-smell'),
-  temperature: document.getElementById('sense-temp')
+  weather: document.getElementById('sense-weather')
 };
 const saveSensesBtn = document.getElementById('save-senses');
 
@@ -381,10 +379,9 @@ saveSensesBtn.addEventListener('click', () => {
   if (!currentArtwork) return;
   const senses = {
     sound: senseInputs.sound.value.trim(),
-    light: senseInputs.light.value.trim(),
-    wind: senseInputs.wind.value.trim(),
+    temperature: senseInputs.temperature.value.trim(),
     smell: senseInputs.smell.value.trim(),
-    temperature: senseInputs.temperature.value.trim()
+    weather: senseInputs.weather.value.trim()
   };
   storeSenses(currentArtwork, senses);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -37,11 +37,10 @@
       <audio id="art-audio" controls class="hidden"></audio>
       <p id="art-description"></p>
       <div id="senses" class="hidden">
-        <label>🎵 <input id="sense-sound" type="text"></label>
-        <label>💡 <input id="sense-light" type="text"></label>
-        <label>🌬️ <input id="sense-wind" type="text"></label>
-        <label>👃 <input id="sense-smell" type="text"></label>
-        <label>🌡️ <input id="sense-temp" type="text"></label>
+        <label>🎵 Sound <input id="sense-sound" type="text"></label>
+        <label>🌡️ Temperature <input id="sense-temp" type="text"></label>
+        <label>👃 Smell <input id="sense-smell" type="text"></label>
+        <label>☀️ Weather <input id="sense-weather" type="text"></label>
         <button type="button" id="save-senses">💾</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace ambiguous sense icons with labeled text inputs for sound, temperature, smell and weather
- Update client logic to store and retrieve the new sensory feedback fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689353c3e84c8327a7239d4f0beb328b