### PR TITLE
style: add banner background to title

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,17 @@
+:root {
+  --page-margin: 2rem;
+}
+
 body {
   font-family: sans-serif;
-  margin: 2rem;
+  margin: var(--page-margin);
+}
+
+#title {
+  background-color: #d9c6a0;
+  margin: calc(var(--page-margin) * -1) calc(var(--page-margin) * -1) 1rem;
+  padding: 1rem;
+  text-align: center;
 }
 
 .hidden {
@@ -88,8 +99,8 @@ img {
 }
 
 @media (max-width: 600px) {
-  body {
-    margin: 1rem;
+  :root {
+    --page-margin: 1rem;
   }
 
   #map {


### PR DESCRIPTION
## Summary
- make "街角ミュージアム" title sit on a full-width banner with color `#d9c6a0`
- centralize page margin via CSS variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b3197b608327aed00de77b268ed1