### PR TITLE
Make layout responsive on small screens

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2,10 +2,17 @@
   --page-margin: 2rem;
 }
 
+/* Ensure elements size correctly within the viewport */
+* {
+  box-sizing: border-box;
+}
+
 body {
   font-family: sans-serif;
   margin: var(--page-margin);
   background-color: #FFFCF2;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
 #title {
@@ -104,8 +111,23 @@ img {
     --page-margin: 1rem;
   }
 
+  .tabs {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tabs button {
+    width: 100%;
+    margin: 0 0 0.5rem 0;
+  }
+
   #map {
     height: 50vh;
+  }
+
+  #post-form input,
+  #post-form button {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Use border-box sizing and prevent horizontal overflow to fit content within the viewport.
- Stack tabs and form fields vertically on screens under 600px for better mobile usability.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b52904548327b002661d1dee4859