### PR TITLE
fix: adjust layout to fit screen width

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -9,9 +9,10 @@
 
 body {
   font-family: sans-serif;
-  margin: var(--page-margin);
+  margin: 0;
+  padding: var(--page-margin);
   background-color: #FFFCF2;
-  max-width: 100vw;
+  max-width: 100%;
   overflow-x: hidden;
 }
 
@@ -50,6 +51,7 @@ img {
   height: 60vh;
   min-height: 300px;
   margin: 1rem 0;
+  width: 100%;
 }
 
 .leaflet-tile {


### PR DESCRIPTION
## Summary
- eliminate body margin and replace with padding to prevent horizontal overflow
- set map container to full width for consistent screen fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b66f64c0832796e5fb4f93fdb6f7