### PR TITLE
fix: hide map in art presence mode on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -36,6 +36,7 @@ body {
 }
 
 .hidden { display: none; }
+#map.hidden { display: none; }
 
 /* タブ：折り返し可能にしてはみ出しを根絶 */
 .tabs {


### PR DESCRIPTION
## Summary
- prevent map from remaining visible on mobile during Art Presence mode by adding an overriding CSS rule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896ec88acbc8327a25f2d92cb007cac