### PR TITLE
Ensure map hidden in art presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -118,6 +118,8 @@ function updateTexts() {
   searchBtn.textContent = t('searchButton');
   document.getElementById('post-btn').textContent = t('postButton');
   presenceToggle.textContent = artPresenceMode ? t('map') : t('presence');
+  document.getElementById('map').classList.toggle('hidden', artPresenceMode);
+  arrow.classList.toggle('hidden', !artPresenceMode);
   setStatus(currentStatusKey, currentStatusExtra);
   if (userMarker) {
     userMarker.bindPopup(t('currentLocation'));
@@ -361,8 +363,6 @@ for (const input of locModeInputs) {
 
 presenceToggle.addEventListener('click', () => {
   artPresenceMode = !artPresenceMode;
-  document.getElementById('map').classList.toggle('hidden', artPresenceMode);
-  arrow.classList.toggle('hidden', !artPresenceMode);
   if (!artPresenceMode) {
     artworkDiv.classList.add('hidden');
     artImage.style.filter = '';


### PR DESCRIPTION
## Summary
- Hide the Leaflet map whenever art presence mode is active
- Show navigation arrow only in presence mode and simplify toggle handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896ede479748327a53dba0f8aaf5111