### PR TITLE
Fix thumbnail images not covering circular markers

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -212,7 +212,7 @@ const arrow = document.getElementById('arrow');
 
 function createImageIcon(url) {
   return L.divIcon({
-    html: `<img src="${url}" />`,
+    html: `<div class="thumb-image" style="background-image:url('${url}')"></div>`,
     className: 'thumb-marker',
     iconSize: [40, 40],
     iconAnchor: [20, 40],

--- a/public/style.css
+++ b/public/style.css
@@ -64,11 +64,16 @@ img {
   animation: pulse 2s infinite;
 }
 
-.thumb-marker img,
+.thumb-marker .thumb-image,
 .thumb-marker .thumb-audio {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.thumb-marker .thumb-image {
+  background-size: cover;
+  background-position: center;
 }
 
 .thumb-marker .thumb-audio {


### PR DESCRIPTION
## Summary
- Ensure map thumbnails fill circular markers by rendering images as background images
- Update CSS to handle new thumb-image class and prevent flex shrinking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976444874483278175ce81506e234d