### PR TITLE
Show media description in presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -317,7 +317,7 @@ function updatePresence() {
     const blur = 20 * ratio;
     artImage.style.filter = `blur(${blur}px)`;
   }
-  artDescription.textContent = minDist < THRESHOLD_METERS ? getDescription(nearest) : '';
+  artDescription.textContent = getDescription(nearest);
 }
 
 function showError(err) {


### PR DESCRIPTION
## Summary
- Always display media descriptions when exploring artworks in presence mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976783f96883278af77a177eb59406