### PR TITLE
Make tab buttons full width on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -113,7 +113,8 @@ img {
     height: 50vh;
   }
 
-  .tabs button {
+  .tabs button,
+  #presence-toggle {
     display: block;
     width: 100%;
     margin-right: 0;
@@ -123,7 +124,7 @@ img {
   .tabs button:last-child {
     margin-bottom: 0;
   }
-}
+  }
 
 #search-results {
   list-style: none;

--- a/public/style.css
+++ b/public/style.css
@@ -112,6 +112,17 @@ img {
   #map {
     height: 50vh;
   }
+
+  .tabs button {
+    display: block;
+    width: 100%;
+    margin-right: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .tabs button:last-child {
+    margin-bottom: 0;
+  }
 }
 
 #search-results {


### PR DESCRIPTION
## Summary
- Ensure map and post tab buttons span the full screen width on mobile by setting them to block elements with 100% width and removing side margins.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976c935c948327bbb9dbf1bfa75f08