### PR TITLE
Hide arrow when near artwork in presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -330,6 +330,7 @@ function updatePresence() {
   }
   artDescription.textContent = getDescription(nearest);
   const within = minDist < THRESHOLD_METERS;
+  arrow.classList.toggle('hidden', within);
   if (within && !presenceWithin) {
     showWelcomeMessage();
   }

--- a/public/app.js
+++ b/public/app.js
@@ -109,8 +109,8 @@ document.getElementById('language-select').addEventListener('change', e => {
 const DEFAULT_ARTWORKS = [
   {
     title: {
-      ja: "spring",
-      en: "春"
+      ja: "春",
+      en: "Spring"
     },
     lat: 34.398520,
     lng: 132.712508,


### PR DESCRIPTION
## Summary
- Hide navigation arrow when user is within 100m of an artwork in art presence mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ec3bb6fc8327a09ea67069310543