### PR TITLE
Hide arrow when near artwork in presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -330,6 +330,8 @@ function updatePresence() {
   }
   artDescription.textContent = getDescription(nearest);
   const within = minDist < THRESHOLD_METERS;
+  arrow.classList.toggle('hidden', within);
+  status.classList.toggle('hidden', within);
   if (within && !presenceWithin) {
     showWelcomeMessage();
   }
@@ -382,6 +384,7 @@ presenceToggle.addEventListener('click', () => {
     if (currentPresenceTarget && currentPresenceTarget.type === 'audio') {
       artAudio.pause();
     }
+    status.classList.remove('hidden');
   }
   updateTexts();
   updatePresence();
@@ -454,6 +457,7 @@ if ('geolocation' in navigator) {
 
 function showArtwork(art) {
   const within = distanceMeters(userLat, userLng, art.lat, art.lng) < THRESHOLD_METERS;
+  status.classList.toggle('hidden', within);
   if (within) {
     setStatus('welcome');
     showWelcomeMessage();


### PR DESCRIPTION
## Summary
- Hide navigation arrow when user is within 100m of an artwork in art presence mode
- Suppress status text when near artwork and restore when leaving presence mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ec3bb6fc8327a09ea67069310543