### PR TITLE
Hide arrow when near artwork in presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,7 @@ const translations = {
   ja: {
     title: "街角ミュージアム",
     map: "マップ",
+    mapMode: "マップモード",
     post: "投稿",
     postArtwork: "作品を投稿",
     newTitlePlaceholder: "タイトル",
@@ -26,6 +27,7 @@ const translations = {
   en: {
     title: "Street Museum",
     map: "Map",
+    mapMode: "Map Mode",
     post: "Post",
     postArtwork: "Post Artwork",
     newTitlePlaceholder: "Title",
@@ -83,7 +85,7 @@ function updateTexts() {
   document.getElementById('location-input').placeholder = t('searchLocationPlaceholder');
   searchBtn.textContent = t('searchButton');
   document.getElementById('post-btn').textContent = t('postButton');
-  presenceToggle.textContent = artPresenceMode ? t('map') : t('explore');
+  presenceToggle.textContent = artPresenceMode ? t('mapMode') : t('explore');
   setStatus(currentStatusKey, currentStatusExtra);
   artworks.forEach(a => {
     if (a.marker) {

--- a/public/app.js
+++ b/public/app.js
@@ -330,6 +330,8 @@ function updatePresence() {
   }
   artDescription.textContent = getDescription(nearest);
   const within = minDist < THRESHOLD_METERS;
+  arrow.classList.toggle('hidden', within);
+  status.classList.toggle('hidden', within);
   if (within && !presenceWithin) {
     showWelcomeMessage();
   }
@@ -382,6 +384,7 @@ presenceToggle.addEventListener('click', () => {
     if (currentPresenceTarget && currentPresenceTarget.type === 'audio') {
       artAudio.pause();
     }
+    status.classList.remove('hidden');
   }
   updateTexts();
   updatePresence();
@@ -454,6 +457,7 @@ if ('geolocation' in navigator) {
 
 function showArtwork(art) {
   const within = distanceMeters(userLat, userLng, art.lat, art.lng) < THRESHOLD_METERS;
+  status.classList.toggle('hidden', within);
   if (within) {
     setStatus('welcome');
     showWelcomeMessage();

--- a/public/app.js
+++ b/public/app.js
@@ -111,8 +111,8 @@ document.getElementById('language-select').addEventListener('change', e => {
 const DEFAULT_ARTWORKS = [
   {
     title: {
-      ja: "spring",
-      en: "春"
+      ja: "春",
+      en: "Spring"
     },
     lat: 34.398520,
     lng: 132.712508,


### PR DESCRIPTION
## Summary
- Hide navigation arrow when user is within 100m of an artwork in art presence mode
- Suppress status text when near artwork and restore when leaving presence mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ec3bb6fc8327a09ea67069310543