### PR TITLE
Fix map centering and user marker after exiting presence mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -387,6 +387,20 @@ presenceToggle.addEventListener('click', () => {
       artAudio.pause();
     }
     status.classList.remove('hidden');
+    if (map && userLat != null && userLng != null) {
+      if (!userMarker) {
+        userMarker = L.circleMarker([userLat, userLng], {
+          radius: 8,
+          color: 'red',
+          fillColor: 'red',
+          fillOpacity: 0.5
+        }).addTo(map);
+      } else {
+        userMarker.setLatLng([userLat, userLng]);
+      }
+      map.setView([userLat, userLng]);
+      setTimeout(() => map.invalidateSize(), 0);
+    }
   }
   updateTexts();
   updatePresence();


### PR DESCRIPTION
## Summary
- Ensure user marker is recreated and map centers on current location when leaving art presence mode
- Invalidate map size after restoring the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f16a77b483279fbd01a0560349b3